### PR TITLE
Build in CI and generate a release on tag pushes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,51 @@
+on: [push]
+
+jobs:
+  build-container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install deps
+        run: |
+          set -ex
+          sudo apt-get update && sudo apt-get install -y binutils-arm-none-eabi
+
+          wget -O /tmp/radiotool.deb https://github.com/v0l/radio_tool/releases/download/v0.2.2/radio_tool-0.2.2-Linux.deb
+          echo "43c887ecfed4a5115097bea2286e7f6ff3a1c174f5bbfeb5d97f85a541ea15e9  /tmp/radiotool.deb" | sha256sum -c
+          sudo apt install -y /tmp/radiotool.deb
+
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source ~/.cargo/env
+          rustup toolchain install nightly && rustup default nightly
+          rustup target add thumbv7em-none-eabi
+
+      - uses: actions/checkout@v3
+      - name: cargo build --release
+        run: source ~/.cargo/env && cargo build --release
+      - run: arm-none-eabi-objcopy -O binary ./target/thumbv7em-none-eabi/release/openlmr ./target/openlmr.bin
+      - run: radio_tool --wrap -o ./target/openlmr_uv3x0.bin -r UV3X0 -s 0x0800C000:./target/openlmr.bin
+      - uses: actions/upload-artifact@v3
+        with:
+          name: build
+          path: target/openlmr_uv3x0.bin
+      - name: create release
+        uses: actions/create-release@v1
+        if: github.ref_type == 'tag'
+        id: create_release
+        with:
+          draft: false
+          prerelease: false
+          release_name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref }}
+          # body_path: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: upload release artifact
+        uses: actions/upload-release-asset@v1
+        if: github.ref_type == 'tag'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./target/openlmr_uv3x0.bin
+          asset_name: openlmr_uv3x0.bin
+          asset_content_type: application/binary


### PR DESCRIPTION
This adds CI to do a test run on every build, and to create releases when you push a tag and attach the build to the release.